### PR TITLE
Add (rough) support for colors with transparency

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,12 @@ var minimums = {
   aaaLarge: 4.5
 };
 
+var flattenColors = function(color, bg) {
+  var alpha = color.alpha();
+
+  return bg.clone().alpha(1).mix(color.clone().alpha(1), alpha);
+};
+
 module.exports = function(colors, options) {
 
   var arr = [];
@@ -49,15 +55,26 @@ module.exports = function(colors, options) {
 
   arr.forEach(function(color) {
     var result = options.compact ? {} : _.clone(color);
-    result.hex = color.hexString();
+    var colorHasAlpha = color.alpha() < 1;
+
+    if (colorHasAlpha) {
+      result.rgba = color.rgbaString();
+    } else {
+      result.hex = color.hexString();
+    }
+
     if (color.name) { result.name = color.name; }
     result.combinations = [];
     arr.forEach(function(bg) {
-      if (color === bg) { return false; }
+      if (color === bg || bg.alpha() < 1) { return false; }
       var combination = options.compact ? {} : _.clone(bg);
+      var contrastColor = colorHasAlpha ? flattenColors(color, bg) : color;
+
       combination.hex = bg.hexString();
+
       if (bg.name) { combination.name = bg.name; }
-      combination.contrast = color.contrast(bg);
+
+      combination.contrast = contrastColor.contrast(bg);
       combination.accessibility = {
         aa: combination.contrast >= minimums.aa,
         aaLarge: combination.contrast >= minimums.aaLarge,
@@ -74,4 +91,3 @@ module.exports = function(colors, options) {
   return results;
 
 };
-


### PR DESCRIPTION
Hey @jxnblk! This is really rough and not tested very well (or at all), but I wanted to see if you'd be interested in this feature before I spent too much time on it. This adds support for checking contrast with rgba/hsla colors.

On a project lately we've been setting text colors using `rgba` scales of white and black, and I wanted to use colorable for our pattern library, so I tried this out to see if it would work.

Let me know if this would be cool and I can clean it up and make sure it works.
