### PR TITLE
Add files fields on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.5",
   "description": "Color palette combination contrast tester",
   "main": "index.js",
+  "files": [
+    "index.js
+  ],
   "scripts": {
     "clean": "rm -r demos & rm bundle.js & rm index.html",
     "copy": "cp -r colorable/* . && rm -r colorable",


### PR DESCRIPTION
I need to fit my bundle and this package is adding a lot of noise:

```
$ pkgfiles

PATH                SIZE     %
.nojekyll           2 B      0%
.npmignore          15 B     0%
webpack.config.js   516 B    0%
test/index.js       1.1 kB   0%
package.json        1.47 kB  0%
index.js            1.78 kB  0%
README.md           2.55 kB  1%
test/template.html  4.06 kB  1%
test/results.json   24.8 kB  6%
index.html          37.3 kB  9%
test/index.html     52.2 kB  12%
bundle.js           295 kB   70%

DIR                 SIZE     %
test/               82.1 kB  20%
.                   421 kB   100%

PKGFILES SUMMARY
Size on Disk with Dependencies  ~3.55 MB
Size with Dependencies          ~3.36 MB
Publishable Size                ~421 kB
Number of Directories           2
Number of Files                 12
```